### PR TITLE
Add Vitest setup with README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Next.js UI Components Example
+
+This project contains a collection of UI components built with Next.js and TypeScript. The components are styled with Tailwind CSS and Radix UI primitives.
+
+## Development
+
+Install dependencies and start the development server:
+
+```sh
+pnpm install
+pnpm dev
+```
+
+## Building
+
+Create a production build with:
+
+```sh
+pnpm build
+```
+
+## Testing
+
+This project uses [Vitest](https://vitest.dev/) for unit testing.
+Run the test suite once:
+
+```sh
+pnpm test
+```
+
+Or watch files and re-run tests on change:
+
+```sh
+pnpm test:watch
+```

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from './utils'
+
+describe('cn utility', () => {
+  it('merges class names', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4')
+  })
+
+  it('handles falsy values', () => {
+    expect(cn('text-sm', false && 'font-bold')).toBe('text-sm')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest",
+    "test:watch": "vitest --watch"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -65,6 +67,7 @@
     "@types/react-dom": "^19",
     "postcss": "^8.5",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.0.0"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+  },
+})


### PR DESCRIPTION
## Summary
- document project usage and testing in README
- add vitest config and example test
- add test scripts in `package.json`

## Testing
- `pnpm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684d6bd5ebe4832f8ddae60462189466