### PR TITLE
Add task group support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ The `TodoApp` component relies on interactive UI features that are difficult to 
 pnpm dev
 ```
 
-Open `http://localhost:3000` in a browser and verify adding, removing, filtering and sorting tasks works as expected.
+Open `http://localhost:3000` in a browser and verify adding, removing, filtering and sorting tasks works as expected. You can now create multiple groups and assign tasks to those groups.


### PR DESCRIPTION
## Summary
- enable multiple groups in the todo app
- persist groups and selected group in local storage
- update UI with group selector and creation form
- document group feature

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858fd9b0ff0832f9c486ed38ead0654